### PR TITLE
Change script name in usage in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ $ ln -s $PWD/git-changemail ~/bin/
 
 ## Usage
 
-`git changemail` or `git changemail -h` must show you how to use it
+`git-changemail` or `git-changemail -h` must show you how to use it
 
 ## Examples
 
 Change author matchings on current branch
 
-    $ git changemail -a old@email.com -n newname -m new@email.com
+    $ git-changemail -a old@email.com -n newname -m new@email.com
 
 Change author and committer matchings on \<branch\> and \<branch2\>. Pass `-f` to filter-branch to allow rewriting backups
 
-    $ git changemail -b old@email.com -n newname -m new@email.com -- -f <branch> <branch2>
+    $ git-changemail -b old@email.com -n newname -m new@email.com -- -f <branch> <branch2>
 
 Show existing users on repo
 
-    $ git changemail --show-both
+    $ git-changemail --show-both
 
 ## Tips
 


### PR DESCRIPTION
As far I understand - script is actually called `git-changemail`, not `git changemail`
